### PR TITLE
Remove unnecessary if statement and fix libcaesium error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,16 +167,13 @@ else ()
     add_executable(${TARGET} ${SOURCES} ${OSX_SOURCES} ${UI} ${RESOURCES} ${CAESIUM_ICON} ${QM_FILES})
     install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(
-        CODE "execute_process(
-            COMMAND ${CMAKE_COMMAND} -E copy
-            ${LIBCAESIUM_SOURCE_DIR}/target/${LIBCAESIUM_BUILD_TYPE}/libcaesium.so
-            /usr/local/lib
-        )"
+        FILES ${LIBCAESIUM_SOURCE_DIR}/target/${LIBCAESIUM_BUILD_TYPE}/libcaesium.so
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
     )
     install(
         CODE "execute_process(
             COMMAND ${CMAKE_COMMAND} -E create_symlink
-            /usr/local/lib/libcaesium.so
+            ${CMAKE_INSTALL_PREFIX}/lib/libcaesium.so
             /usr/lib/libcaesium.so
         )"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,9 @@ set(LIBCAESIUM_SOURCE_DIR ${CMAKE_BINARY_DIR}/libcaesium-prefix/src/libcaesium)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
-endif()
+endif ()
 
-if (CMAKE_BUILD_TYPE)
-    string(TOLOWER ${CMAKE_BUILD_TYPE} LIBCAESIUM_BUILD_TYPE)
-endif()
+string(TOLOWER ${CMAKE_BUILD_TYPE} LIBCAESIUM_BUILD_TYPE)
 
 if (NOT WIN32)
     link_directories(${LIBCAESIUM_SOURCE_DIR}/target/${LIBCAESIUM_BUILD_TYPE})
@@ -168,6 +166,20 @@ elseif (APPLE)
 else ()
     add_executable(${TARGET} ${SOURCES} ${OSX_SOURCES} ${UI} ${RESOURCES} ${CAESIUM_ICON} ${QM_FILES})
     install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(
+        CODE "execute_process(
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${LIBCAESIUM_SOURCE_DIR}/target/${LIBCAESIUM_BUILD_TYPE}/libcaesium.so
+            /usr/local/lib
+        )"
+    )
+    install(
+        CODE "execute_process(
+            COMMAND ${CMAKE_COMMAND} -E create_symlink
+            /usr/local/lib/libcaesium.so
+            /usr/lib/libcaesium.so
+        )"
+    )
 endif ()
 
 # --- libcaesium ---


### PR DESCRIPTION
caesium-image-compressor: error while loading shared libraries: libcaesium.so: cannot open shared object file: No such file or directory

Install target doesn't copy libcaesium.so to the install prefix and symlinks it to /usr/lib/libcaesium.so, thus causing Caesium Image Compressor to fail to locate it.