### PR TITLE
Fixed issue #234

### DIFF
--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -242,7 +242,7 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
             }
         }
 
-        bool copyResult = False
+        bool copyResult = false
         if (!outputIsBiggerThanInput) {
             inputCopyFile = tempFileFullPath;
             copyResult = QFile::copy(inputCopyFile, outputFullPath);

--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -244,16 +244,21 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
 
         if (!outputIsBiggerThanInput) {
             inputCopyFile = tempFileFullPath;
+            bool copyResult = QFile::copy(inputCopyFile, outputFullPath);
         } else {
             this->status = CImageStatus::WARNING;
             this->additionalInfo = QIODevice::tr("Skipped: compressed file is bigger than original");
+            // Overwrite output file name with original file name to avoid broken extension (ex: .png named .webp) 
+            fullFileName = inputFileInfo.filename()
+            outputFullPath = outputDir.absoluteFilePath(fullFileName);    
+            bool copyResult = QFile::copy(inputCopyFile, outputFullPath);
             if (outputAlreadyExists) {
                 QFileInfo outputFileInfo = QFileInfo(outputFullPath);
                 this->setCompressedInfo(outputFileInfo);
                 return true;
             }
         }
-        bool copyResult = QFile::copy(inputCopyFile, outputFullPath);
+        
         if (!copyResult) {
             qCritical() << "Failed to copy from" << inputCopyFile << "to" << outputFullPath;
             this->additionalInfo = QIODevice::tr("Cannot copy output file, check your permissions");

--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -242,7 +242,7 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
             }
         }
 
-        bool copyResult = false
+        bool copyResult = false;
         if (!outputIsBiggerThanInput) {
             inputCopyFile = tempFileFullPath;
             copyResult = QFile::copy(inputCopyFile, outputFullPath);

--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -250,7 +250,7 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
             this->status = CImageStatus::WARNING;
             this->additionalInfo = QIODevice::tr("Skipped: compressed file is bigger than original");
             // Overwrite output file name with original file name to avoid broken extension (ex: .png named .webp) 
-            fullFileName = inputFileInfo.filename()
+            fullFileName = inputFileInfo.filename();
             outputFullPath = outputDir.absoluteFilePath(fullFileName);    
             copyResult = QFile::copy(inputCopyFile, outputFullPath);
             if (outputAlreadyExists) {

--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -250,7 +250,7 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
             this->status = CImageStatus::WARNING;
             this->additionalInfo = QIODevice::tr("Skipped: compressed file is bigger than original");
             // Overwrite output file name with original file name to avoid broken extension (ex: .png named .webp) 
-            fullFileName = inputFileInfo.filename();
+            fullFileName = inputFileInfo.fileName();
             outputFullPath = outputDir.absoluteFilePath(fullFileName);    
             copyResult = QFile::copy(inputCopyFile, outputFullPath);
             if (outputAlreadyExists) {

--- a/src/models/CImage.cpp
+++ b/src/models/CImage.cpp
@@ -242,16 +242,17 @@ bool CImage::compress(const CompressionOptions& compressionOptions)
             }
         }
 
+        bool copyResult = False
         if (!outputIsBiggerThanInput) {
             inputCopyFile = tempFileFullPath;
-            bool copyResult = QFile::copy(inputCopyFile, outputFullPath);
+            copyResult = QFile::copy(inputCopyFile, outputFullPath);
         } else {
             this->status = CImageStatus::WARNING;
             this->additionalInfo = QIODevice::tr("Skipped: compressed file is bigger than original");
             // Overwrite output file name with original file name to avoid broken extension (ex: .png named .webp) 
             fullFileName = inputFileInfo.filename()
             outputFullPath = outputDir.absoluteFilePath(fullFileName);    
-            bool copyResult = QFile::copy(inputCopyFile, outputFullPath);
+            copyResult = QFile::copy(inputCopyFile, outputFullPath);
             if (outputAlreadyExists) {
                 QFileInfo outputFileInfo = QFileInfo(outputFullPath);
                 this->setCompressedInfo(outputFileInfo);


### PR DESCRIPTION
https://github.com/Lymphatus/caesium-image-compressor/issues/234

Theoretically should fix the issue. Unfortunately, I don't have a Mac to build on and double-check.

Simply changes the copy path to have the original filename + extension suffix instead of the new one.