### PR TITLE
build: Fix libcaesium lookup on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else ()
     project(${TARGET} LANGUAGES CXX)
 endif ()
 
-#find_library(LIBCAESIUM caesium)
+find_library(LIBCAESIUM caesium)
 if (NOT LIBCAESIUM)
     find_program(CARGO "cargo" REQUIRED)
 endif ()


### PR DESCRIPTION
I'm not sure why this commit df6f440 comment out the line to find libcaesium in CMakeList.txt but if it is intentional, we could try to find a workaround