### PR TITLE
Update Cmake list for Qt Linguist option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(QT_LINGUIST_OPTIONS "--no-obsolete")
+set(QT_LINGUIST_OPTIONS "-no-obsolete")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(LUPDATE_OPTIONS "-no-obsolete -no-ui-lines")
+set(LUPDATE_OPTIONS "-no-ui-lines")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,18 +155,18 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(LUPDATE_OPTIONS "-no-obsolete -no-ui-lines")
+set(LUPDATE_OPTIONS "-no-obsolete")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
-    qt6_create_translation(QM_FILES
+    qt_add_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             ${QT_LINGUIST_OPTIONS}
             ${LUPDATE_OPTIONS}
             )
 else ()
-    qt5_create_translation(QM_FILES
+    qt_add_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             ${LUPDATE_OPTIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,11 +159,13 @@ set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINAR
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
-            ${TS_FILES})
+            ${TS_FILES}
+            )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
-            ${TS_FILES})
+            ${TS_FILES}
+            )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,20 +155,20 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(LUPDATE_OPTIONS "-no-obsolete")
+set(LUPDATE_OPTIONS "-no-obsolete -no-ui-lines")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS -no-obsolete
+            OPTIONS ${LUPDATE_OPTIONS}
             )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS -no-obsolete
+            OPTIONS ${LUPDATE_OPTIONS}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,13 +159,13 @@ set(LUPDATE_OPTIONS "-no-obsolete")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
-    qt_add_translation(QM_FILES
+    qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
             )
 else ()
-    qt_add_translation(QM_FILES
+    qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             LUPDATE_OPTIONS ${LUPDATE_OPTIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,16 +155,20 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
+set(QT_LINGUIST_OPTIONS "--no-obsolete")
+    
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
+            ${QT_LINGUIST_OPTIONS}
             )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
+            ${QT_LINGUIST_OPTIONS}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,13 +162,15 @@ if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS "-no-ui-lines -no-oboslete"
+            OPTIONS "-no-obsolete"
+            OPTIONS "-no-ui-lines"
             )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS "-no-ui-lines -no-oboslete"
+            OPTIONS "-no-obsolete"
+            OPTIONS "-no-ui-lines"
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(QT_LINGUIST_OPTIONS "-no-obsolete")
+set(LUPDATE_OPTIONS "-no-obsolete -no-ui-lines")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
@@ -163,12 +163,13 @@ if (QT_VERSION_MAJOR EQUAL "6")
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             ${QT_LINGUIST_OPTIONS}
+            ${LUPDATE_OPTIONS}
             )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            ${QT_LINGUIST_OPTIONS}
+            ${LUPDATE_OPTIONS}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,15 +160,15 @@ set(LUPDATE_OPTIONS "-no-obsolete")
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
-            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
-            -ts ${TS_FILES}
+            ${TS_FILES}
+            OPTIONS -no-obsolete
             )
 else ()
     qt5_create_translation(QM_FILES
-            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
-            -ts ${TS_FILES}
+            ${TS_FILES}
+            OPTIONS -no-obsolete
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,13 +159,13 @@ set(LUPDATE_OPTIONS "-no-obsolete")
     
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
-    qt5_create_translation(QM_FILES
+    qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
             )
 else ()
-    qt6_create_translation(QM_FILES
+    qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
             LUPDATE_OPTIONS ${LUPDATE_OPTIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,16 +160,15 @@ set(LUPDATE_OPTIONS "-no-obsolete")
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt_add_translation(QM_FILES
+            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            ${QT_LINGUIST_OPTIONS}
-            ${LUPDATE_OPTIONS}
             )
 else ()
     qt_add_translation(QM_FILES
+            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            ${LUPDATE_OPTIONS}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,15 +160,15 @@ set(LUPDATE_OPTIONS "-no-obsolete")
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt_add_translation(QM_FILES
-            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
+            LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
             )
 else ()
     qt_add_translation(QM_FILES
-            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
+            LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,13 +162,13 @@ if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS ${LUPDATE_OPTIONS}
+            OPTIONS "-no-ui-lines -no-oboslete"
             )
 else ()
     qt5_create_translation(QM_FILES
             ${CMAKE_SOURCE_DIR}
             ${TS_FILES}
-            OPTIONS ${LUPDATE_OPTIONS}
+            OPTIONS "-no-ui-lines -no-oboslete"
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,6 @@ SET(TS_FILES
         resources/i18n/caesium_fi_FI.ts
 )
 
-set(LUPDATE_OPTIONS "-no-ui-lines")
-    
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,15 +160,15 @@ set(LUPDATE_OPTIONS "-no-obsolete")
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_BINARY_DIR}/i18n)
 if (QT_VERSION_MAJOR EQUAL "6")
     qt6_create_translation(QM_FILES
+            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
-            ${TS_FILES}
-            LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
+            -ts ${TS_FILES}
             )
 else ()
     qt5_create_translation(QM_FILES
+            ${LUPDATE_OPTIONS}
             ${CMAKE_SOURCE_DIR}
-            ${TS_FILES}
-            LUPDATE_OPTIONS ${LUPDATE_OPTIONS}
+            -ts ${TS_FILES}
             )
 endif ()
 configure_file(resources/languages.qrc ${CMAKE_BINARY_DIR} COPYONLY)


### PR DESCRIPTION
@Lymphatus 

Add variable for LUPDATE_OPTIONS

Please merge and run compilation in your environment.
Please relase a new build with new instalelr.

Pleasse consider that as defined here 

https://doc.qt.io/qt-6/qtlinguist-cmake-qt-create-translation.html 

seems that "qt_create_translation" is a deprecated function
The function suggested is 

"qt6_add_lupdate" - https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-lupdate.html
or qt6_add_translations - https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-translations.html


