### PR TITLE
Update entire CImageTreeModel table on compression finish.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -629,6 +629,16 @@ void MainWindow::startCompression(bool onlyFailed)
 
     this->compressionWatcher = new QFutureWatcher<void>();
     connect(this->compressionWatcher, &QFutureWatcherBase::finished, this, &MainWindow::compressionFinished);
+    
+    connect(this->compressionWatcher, &QFutureWatcherBase::finished, [this] {
+        
+        size_t rowCount = this->cImageModel->rowCount();
+    
+        for(size_t i = 0; i < rowCount; ++i) {
+            this->cImageModel->emitDataChanged(i);
+        }
+    });
+
     connect(this->compressionWatcher, &QFutureWatcherBase::progressValueChanged, this->cImageModel, &CImageTreeModel::emitDataChanged);
     connect(this->compressionWatcher, &QFutureWatcherBase::progressValueChanged, this, &MainWindow::updateCompressionProgressLabel);
 


### PR DESCRIPTION
The images table now does not update all of its contents when compression finishes. It redraws only when you put a cursor over it (1st video). I propose a quick fix, to emit dataChanged on compression finish. 2nd video demonstrates that the issue is gone.

Before fix: https://github.com/user-attachments/assets/0e1ca118-06cd-4cea-93e3-79ac1c2d38d8

After fix: https://github.com/user-attachments/assets/d2844394-e5a5-4766-ab3a-fb94f2201ddd

